### PR TITLE
[babel-preset] Change the default core-js version in our preset

### DIFF
--- a/packages/babel-preset/CHANGELOG.md
+++ b/packages/babel-preset/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Changed the default `corejs` version for `node` and `web` presets (default = `3`) [[#48](https://github.com/Shopify/babel-preset-shopify/pull/48)]
+
 🚨Package rename
 
 This package has been renamed from `babel-preset-shopify` to `@shopify/babel-preset`.

--- a/packages/babel-preset/node.js
+++ b/packages/babel-preset/node.js
@@ -4,7 +4,7 @@ module.exports = function shopifyNodePreset(_api, options = {}) {
   const {
     version = 'current',
     modules = 'commonjs',
-    corejs = 2,
+    corejs = 3,
     debug = false,
     useBuiltIns = 'entry',
     typescript = false,

--- a/packages/babel-preset/web.js
+++ b/packages/babel-preset/web.js
@@ -3,7 +3,7 @@ const nonStandardPlugins = require('./non-standard-plugins');
 module.exports = function shopifyWebPreset(_api, options = {}) {
   const {
     modules = 'commonjs',
-    corejs = 2,
+    corejs = 3,
     debug = false,
     browsers,
     useBuiltIns = 'entry',


### PR DESCRIPTION
This PR is the first step of https://github.com/Shopify/sewing-kit/pull/1899

Changed the default version of core-js. 🎉

[According to the doc](https://github.com/zloirock/core-js#babelpreset-env), we should specify the minor core-js version. 
>Warning! Recommended to specify used minor core-js version, like corejs: '3.6', instead of corejs: 3, since with corejs: 3 will not be injected modules which were added in minor core-js releases.

I will redefine the `core-js` version to use the minor version in `sewing-kit`.