### PR TITLE
[ESLint-plugin] Add eslint 'graphql/required-fields' rule for 'id' field 

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Added
+
+- Added `id` field to `graphql/required-fields` rule. ([#166](https://github.com/Shopify/web-foundation/pull/166)).
 
 ## [38.0.0]
 

--- a/packages/eslint-plugin/lib/config/rules/graphql.js
+++ b/packages/eslint-plugin/lib/config/rules/graphql.js
@@ -4,5 +4,11 @@ module.exports = {
   'graphql/named-operations': ['error', {env: 'literal'}],
   'graphql/no-deprecated-fields': ['error', {env: 'literal'}],
   'graphql/template-strings': ['error', {env: 'literal'}],
-  'graphql/required-fields': 'off',
+  'graphql/required-fields': [
+    'error',
+    {
+      env: 'literal',
+      requiredFields: ['id'],
+    },
+  ],
 };

--- a/packages/eslint-plugin/tests/fixtures/prettier-graphql/app/graphql/Query.graphql
+++ b/packages/eslint-plugin/tests/fixtures/prettier-graphql/app/graphql/Query.graphql
@@ -1,6 +1,6 @@
 query IgnoredFooQuery {
-  foo        {
+  foo {
+    id
     bar
-
   }
 }

--- a/packages/eslint-plugin/tests/lib/config/graphql.test.js
+++ b/packages/eslint-plugin/tests/lib/config/graphql.test.js
@@ -12,6 +12,16 @@ describe('config', () => {
       ).toMatch(/Cannot query field .*DOES_NOT_EXIST/);
     }, 8000);
 
+    it('validates .graphql files with required `id` field using graphql plugin', () => {
+      expect(
+        execESLint(
+          `--ext .graphql --ignore-pattern "**/graphql-lint-error/build/*" --config "${configFile(
+            'graphql',
+          )}" "${fixtureFile('graphql-lint-error')}"`,
+        ),
+      ).toMatch(/'id' field required on 'foo'/);
+    }, 8000);
+
     it('validates .graphql file syntax using graphql plugin', () => {
       expect(
         execESLint(


### PR DESCRIPTION
## Description

Added `id` field to graphl/required-fields eslint rule. This rule has been added in Web (https://github.com/Shopify/web/pull/27464) and Plus-Web (https://github.com/Shopify/plus-web/pull/4203) and should be a Shopify-wide rule, given the advantages of always requiring the id field in graphql queries. 

A full analysis of the reasoning for the rule, as well as the advantage/risk analysis can be found [here](https://docs.google.com/document/d/1c_F-ywvuNLRnierZJ6KO_wXgp-X-dE4wQibCcv3P9bE).

#### Changelogs
- [eslint-plugin](https://github.com/Shopify/web-foundation/blob/add-graphql-required-field-id/packages/eslint-plugin/CHANGELOG.md)

#### New rules I enabled
-  [graphql/required-fields](https://github.com/Shopify/web-foundation/blob/add-graphql-required-field-id/packages/eslint-plugin/lib/config/rules/graphql.js#L7-L13)

## Type of change
<!--
If this pull request changes multiple packages, please indicate the type of change for each package.
If this is a new package, you may disregard this section.
Please delete options that are not relevant.
-->
- [x] [ESLint-plugin] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)