### PR TITLE
New eslint default for jest formatting

### DIFF
--- a/packages/eslint-plugin/lib/config/jest.js
+++ b/packages/eslint-plugin/lib/config/jest.js
@@ -10,7 +10,7 @@ module.exports = {
     sourceType: 'module',
   },
 
-  plugins: ['jest', '@shopify'],
+  plugins: ['jest', 'jest-formatting', '@shopify'],
 
   rules: merge(require('./rules/jest'), {
     'jest/valid-title': [

--- a/packages/eslint-plugin/lib/config/rules/jest-formatting.js
+++ b/packages/eslint-plugin/lib/config/rules/jest-formatting.js
@@ -1,0 +1,16 @@
+// see https://github.com/dangreenisrael/eslint-plugin-jest-formatting#usage
+
+module.exports = {
+  // Require padding around afterAll blocks
+  'jest-formatting/padding-around-after-all-blocks': 'error',
+  // Require padding around afterEach blocks
+  'jest-formatting/padding-around-after-each-blocks': 'error',
+  // Require padding around beforeAll blocks
+  'jest-formatting/padding-around-before-all-blocks': 'error',
+  // Require padding around beforeEach blocks
+  'jest-formatting/padding-around-before-each-blocks': 'error',
+  // Require padding around describe blocks
+  'jest-formatting/padding-around-describe-blocks': 'error',
+  // Require padding around test/it blocks
+  'jest-formatting/padding-around-test-blocks': 'error',
+};

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -45,6 +45,7 @@
     "eslint-plugin-graphql": "3.1.1",
     "eslint-plugin-import": "2.22.0",
     "eslint-plugin-jest": "23.13.0",
+    "eslint-plugin-jest-formatting": "2.0.0",
     "eslint-plugin-jsx-a11y": "6.2.3",
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-prettier": "3.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3390,6 +3390,11 @@ eslint-plugin-import@2.22.0:
     resolve "^1.17.0"
     tsconfig-paths "^3.9.0"
 
+eslint-plugin-jest-formatting@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest-formatting/-/eslint-plugin-jest-formatting-2.0.0.tgz#6688feefb9c8c49ff847160e9284bc405d44f360"
+  integrity sha512-DLL2vg+cXmtONUBiIVE4nk9YQXnpT2ljHfAvW1vRYOGFA9Jfo5kqG+1lzYxcnphdFyUFN0Tx+rGkmsAZy2paxA==
+
 eslint-plugin-jest@23.13.0:
   version "23.13.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-23.13.0.tgz#a80ec992b155dd15260bf1131bad666e5123e551"


### PR DESCRIPTION
Addresses #126

Introduces the [eslint-plugin-jest-formatting](https://www.npmjs.com/package/eslint-plugin-jest-formatting) eslint plugin and configures the recommended settings to ship as part of our `@shopify/jest` eslint plugin.

This enforces some rules about the code styling of the blocks used in jest tests, for example: `jest-formatting/padding-around-after-all-blocks` which states:

Examples of **incorrect** code for this rule:

```js
const someText = 'abc';
afterAll(() => {});
describe('someText', () => {});
```

Examples of **correct** code for this rule:

```js
const someText = 'abc';

afterAll(() => {});

describe('someText', () => {});
```
