### PR TITLE
Add Pull Requests template to the repo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+## Description
+
+Fixes (issue #)
+
+<!--
+Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
+-->
+
+## Type of change
+
+<!--
+If this pull request changes multiple packages, please indicate the type of change for each package.
+
+If this is a new package, you may disregard this section.
+
+Please delete options that are not relevant.
+-->
+
+- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
+- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
+- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+## Checklist
+
+- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)


### PR DESCRIPTION
Since more external contributors start contributing back to the web-foundation repo, we need a PR template. I copied the one from quilt.