### PR TITLE
🥼🧪✨ Part 1 - Change to Web-Configs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,29 +1,27 @@
-# Web Foundation: a contributor's guide
+# Web Configs: a contributor's guide
 
 This guide is tailored to Shopifolk, although we welcome contributions from [the broader development community](#external-contributors) as well.
 
 ## [Code of conduct](./CODE_OF_CONDUCT.md).
 
-Shopify has adopted a Code of Conduct that we expect Web Foundation contributors to adhere to. Please read the [full text](./CODE_OF_CONDUCT.md) so that you can understand what actions will and will not be tolerated.
+Shopify has adopted a Code of Conduct that we expect contributors to adhere to. Please read the [full text](./CODE_OF_CONDUCT.md) so that you can understand what actions will and will not be tolerated.
 
 ## Ways to contribute
 
-There are many ways to contribute to Web Foundation, some of which are:
+There are many ways to contribute, some of which are:
 
-- Filing [bug reports](https://github.com/Shopify/web-foundation/issues/new?template=BUG_REPORT.md)
-- Requesting new features or packages via [an issue](https://github.com/Shopify/web-foundation/issues/new/choose)
+- Filing [bug reports](https://github.com/Shopify/web-configs/issues/new?template=BUG_REPORT.md)
+- Requesting new features or packages via [an issue](https://github.com/Shopify/web-configs/issues/new/choose)
   - Bringing up areas for enhancement
-- Hacking away on an issue from our [backlog](https://github.com/Shopify/web-foundation/issues)
+- Hacking away on an issue from our [backlog](https://github.com/Shopify/web-configs/issues)
 - Improving tests or documentation
-
-Want to contribute, but not sure how? Find us on Slack in `#web-foundation-tech`.
 
 ## Development
 
 ### Getting Started
 
 ```bash
-dev clone web-foundation
+dev clone web-configs
 dev up
 ```
 
@@ -35,7 +33,7 @@ We are adding documentation as we go in the [handbook](../handbook). There you w
 
 The [documentation](../docs) directory in this repo covers the more granular technical aspects of this project. Of particular note for new folks are the following:
 
-- [Guides](../docs/guides): a set of guides to help you get started developing with `web-foundation`. Of particular note for developers just starting on the project is our guide to [creating a new package](../docs/guides/creating-a-new-package.md).
+- [Guides](../docs/guides): a set of guides to help you get started developing with `web-configs`. Of particular note for developers just starting on the project is our guide to [creating a new package](../docs/guides/creating-a-new-package.md).
 - [FAQ](../docs/FAQ.md): common questions about the project in general, as well as some of the technical pieces within.
 - [Resources](../docs/resources.md): good resources for understanding this project’s tech stack.
 - [Getting started](../docs/getting-started.md): some tools we recommend for getting the most out of this project.
@@ -50,14 +48,14 @@ More usage instructions on the `tophat` command can be [found here](https://gith
 
 ### Documentation
 
-If your change affects the public API of any packages within Web-Foundation (i.e. adding or
+If your change affects the public API of any packages within this repository (i.e. adding or
 changing arguments to a function, adding a new function, changing the
 return value, etc), please ensure the documentation is also updated to
 reflect this. Documentation is in the `README.md` files of each package. If further documentation is needed please communicate via Github Issues.
 
 ### Testing
 
-The packages in Web-Foundation are used in mission-critical production scenarios. As such, we try not to merge any untested code. The coverage doesn't strictly need to be 100% across the board, but testing should remain a primary concern.
+The packages in this repository are used in mission-critical production scenarios. As such, we try not to merge any untested code. The coverage doesn't strictly need to be 100% across the board, but testing should remain a primary concern.
 
 To run the full test suite, simply run `dev test`.
 
@@ -75,7 +73,7 @@ Another option, if you'd like to break work down into reviewable chunks, is to u
 
 ## Releasing
 
-The release process currently involves some manual steps to complete. Please ping Web Foundations ATC in the `#web-foundation-tech` Slack channel when you're ready to merge a new PR into `main`, and we will orchestrate a new release. The repo owner can follow [this guide](../docs/guides/release-and-deploy.md) to create a release.
+The release process currently involves some manual steps to complete. Once your PR has been merged, our team will orchestrate when to cut a new release.
 
 **Note** Version numbers in `package.json` files should never be altered manually. This will be done via scripts as part of the release process.
 
@@ -86,7 +84,7 @@ The release process currently involves some manual steps to complete. Please pin
 To start working on the codebase, first fork the repo, then clone it:
 
 ```
-git clone git@github.com:your-username/web-foundation.git
+git clone git@github.com:your-username/web-configs.git
 ```
 
 _Note: replace "your-username" with your Github handle_

--- a/README.md
+++ b/README.md
@@ -1,19 +1,15 @@
 [comment]: # (NOTE: This file is generated and should not be modify directly. Update `templates/ROOT_README.hbs.md` instead)
 
-**Note: Old documentation on the root level has been moved inside the [handbook](handbook) directory of this repository**
-
-# Web foundation
+# Web Configs
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md)
-[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=main)](https://travis-ci.com/Shopify/web-foundation)
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lernajs.io/)
 
 This repository contains common configuration and living [guidances](handbook) that Shopify uses to build web UI.
 
 ## Usage
 
-The Web foundation repo is managed as a monorepo that is composed of many npm packages.
-Each package has its own `README` and documentation describing usage.
+The Web Configs repo is managed as a monorepo that is composed of many npm packages, where each package has its own `README` and documentation describing usage.
 
 ### Package Index
 
@@ -30,11 +26,7 @@ Each package has its own `README` and documentation describing usage.
 
 ## Want to contribute?
 
-Check out our [Contributing Guide](./.github/CONTRIBUTING.md)
-
-## Questions?
-
-For Shopifolk, you can reach out to us in Slack in the `#web-foundation-tech` channel. For external inquiries, we welcome bug reports, enhancements, and feature requests via Github issues.
+Check out our [Contributing Guide](./.github/CONTRIBUTING.md). We welcome bug reports, enhancements, and feature requests via Github issues.
 
 ## License
 

--- a/dev.yml
+++ b/dev.yml
@@ -1,4 +1,4 @@
-name: web-foundation
+name: web-configs
 up:
   - node:
       yarn: v1.19.1
@@ -7,6 +7,6 @@ commands:
   __default__: start
   check: yarnpkg check
   lint: yarnpkg lint
-  start: echo "Running web-foundation is not really a concept that makes sense."
+  start: echo "Running web-configs is not really a concept that makes sense."
   test: yarnpkg test
   generate: yarnpkg generate

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,3 +1,3 @@
 # Frequently asked questions (FAQ)
 
-Have a question that you think should be included in our FAQ? Please help us by creating an [issue](https://github.com/Shopify/web-foundation/issues/new?template=ENHANCEMENT.md) or opening a pull request.
+Have a question that you think should be included in our FAQ? Please help us by creating an [issue](https://github.com/Shopify/web-configs/issues/new?template=ENHANCEMENT.md) or opening a pull request.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,8 +12,6 @@ In addition to this documentation, contributors generally have an in-depth under
 - Node.JS
 - Jest
 
-If you're looking to enhance your understanding of these technologies, feel free to reach out in `#web-foundation-tech` on Slack.
-
 ## Tools
 
 The tools below will give you the best developer experience with this project:

--- a/docs/guides/creating-a-new-package.md
+++ b/docs/guides/creating-a-new-package.md
@@ -5,17 +5,13 @@ There are many steps involved in creating a new package, and you can contribute 
 ## Filing issues
 
 Discovered a problem that you'd like us to solve? Have an idea for a new package?
-Submit a [feature request](https://github.com/Shopify/web-foundation/issues/new?template=FEATURE_REQUEST.md).
+Submit a [feature request](https://github.com/Shopify/web-configs/issues/new?template=FEATURE_REQUEST.md).
 
 ## Development
 
 Once we've identified a package you would like to add, it's time to begin the process of creating a PR. If you haven't set up your development environment, there are instructions for getting started in our [contributing guide](../../.github/CONTRIBUTING.md).
 
 You should create your new package with the generator. Simply run `yarn generate:package` and follow the prompts to set up the initial boilerplate.
-
-### Naming
-
-If you need help with finding a good name for your package, feel free to reach our in `#web-foundation-tech` on Slack, or else just pick a relevant name and add a comment to the PR asking for feedback.
 
 ## Trading in a PR
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,3 +1,3 @@
 # Resources
 
-Have a resource that you think should be included in this list? Please help us by creating an [issue](https://github.com/Shopify/web-foundation/issues/new?template=ENHANCEMENT.md) or opening a pull request.
+Have a resource that you think should be included in this list? Please help us by creating an [issue](https://github.com/Shopify/web-configs/issues/new?template=ENHANCEMENT.md) or opening a pull request.

--- a/handbook/Best practices/TypeScript/README.md
+++ b/handbook/Best practices/TypeScript/README.md
@@ -18,8 +18,8 @@ This guide covers Shopify's approach to using TypeScript. It also highlights our
 
 Additional tooling is heavily integrated into TypeScript projects at Shopify to improve our development experience and developer confidence.
 
-* [`@shopify/typescript-configs`](https://github.com/Shopify/web-foundation/tree/main/packages/typescript-configs): Common base configuration files to simplify TypeScript project setup.
-* [`@shopify/eslint-plugin` TypeScript config](https://github.com/Shopify/web-foundation/blob/main/packages/eslint-plugin/lib/config/typescript.js) ESLint config for TypeScript codebases
+* [`@shopify/typescript-configs`](https://github.com/Shopify/web-configs/tree/main/packages/typescript-configs): Common base configuration files to simplify TypeScript project setup.
+* [`@shopify/eslint-plugin` TypeScript config](https://github.com/Shopify/web-configs/blob/main/packages/eslint-plugin/lib/config/typescript.js) ESLint config for TypeScript codebases
 * [`graphql-typescript-definitions`](https://github.com/Shopify/graphql-tools-web/tree/main/packages/graphql-typescript-definitions): Tooling to generate TypeScript definition files from .graphql documents
 * [`@shopify/useful-types`](https://github.com/Shopify/quilt/tree/main/packages/useful-types): A few handy TypeScript types.
 

--- a/handbook/Decision records/00 - Use a Lerna monorepo.md
+++ b/handbook/Decision records/00 - Use a Lerna monorepo.md
@@ -15,7 +15,7 @@ We implement our common non-tooling non-polaris libraries as a monorepo based on
 
 ## Problem space
 
-The web foundation team's number of open source packages is set to grow exponentially as we pull libraries out of web. As of now we estimate [at least 19 new libraries](https://github.com/Shopify/web/projects/17) will need to be available to our React web projects.
+The Web Foundations team's number of open source packages is set to grow exponentially as we pull libraries out of web. As of now we estimate [at least 19 new libraries](https://github.com/Shopify/web/projects/17) will need to be available to our React web projects.
 
 In the past we've tried pulling common bits of functionality into some chunky overly-broadly-named repos, such as [@shopify/javascript-utilities](https://github.com/Shopify/javascript-utilities) and [@shopify/react-utilities](https://github.com/Shopify/react-utilities). We wanted to avoid problems with maintaining highly granular packages by essentially packing multiple simple packages into domain-based mega-packages. However, thanks to the dependency between the two, even at this level these ended up underdeveloped and poorly maintained. They fell victim to the same set of problems that most multi-repo dependency graphs must overcome:
 

--- a/handbook/Decision records/01 - Use our own testing library for testing React codebases.md
+++ b/handbook/Decision records/01 - Use our own testing library for testing React codebases.md
@@ -14,7 +14,7 @@ We use and maintain [`@shopify/react-testing`](https://github.com/Shopify/quilt/
 
 ## Problem space
 
-There are a number of testing libraries available for React applications. The most popular of these focus on testing the behaviour of components in response to initial data and subsequent user interaction and the composition of components together. Testing of the actual visual output of a component is usually not included in the scope of these libraries, or is encouraged to be done via snapshots of the DOM (which is highly [problematic](https://github.com/Shopify/web-foundation/blob/main/handbook/Decision%20records/03%20-%20We%20do%20not%20use%20Jest%20snapshot%20tests.md)).
+There are a number of testing libraries available for React applications. The most popular of these focus on testing the behaviour of components in response to initial data and subsequent user interaction and the composition of components together. Testing of the actual visual output of a component is usually not included in the scope of these libraries, or is encouraged to be done via snapshots of the DOM (which is highly [problematic](https://github.com/Shopify/web-configs/blob/main/handbook/Decision%20records/03%20-%20We%20do%20not%20use%20Jest%20snapshot%20tests.md)).
 
 ### Prior Art #1 - Enzyme
 
@@ -23,7 +23,7 @@ There are a number of testing libraries available for React applications. The mo
 Unfortunately, Enzyme has a number of downsides for our usecase.
 
 - It has frequently taken a long time to support new React features (specifically, it took quite a while for it to properly support hooks)
-- It has a very large API surface area, much of which works against Shopify’s [testing conventions](https://github.com/Shopify/web-foundation/blob/main/Best%20practices/react/Testing.md). For example, Enzyme provides APIs like `setState` which encourage reaching in to implementation details of your components
+- It has a very large API surface area, much of which works against Shopify’s [testing conventions](https://github.com/Shopify/web-configs/blob/main/Best%20practices/react/Testing.md). For example, Enzyme provides APIs like `setState` which encourage reaching in to implementation details of your components
 - Enzyme is unlikely to add features we use or need in a testing library, such as automatic unmounting and a built-in version `trigger()`
 - Enzyme tends to continue to support a large backlog of React versions, which makes contribution more difficult
 
@@ -33,7 +33,7 @@ Unfortunately, Enzyme has a number of downsides for our usecase.
 
 While this premise of writing tests that mirror user actions is compelling, basing all tests off the raw DOM being produced has a number of problems.
 
-- Relying exclusively on DOM output can actually lead to testing **more** implementation details rather than less. Users generally do not interact with things based on constructs like test-ids ([see our previous decision log about test-ids](https://github.com/Shopify/web-foundation/blob/main/handbook/Decision%20records/04%20-%20We%20do%20not%20use%20test%20IDs.md)), or even by actual HTML attributes. The DOM itself is not a public API from a user's perspective.
+- Relying exclusively on DOM output can actually lead to testing **more** implementation details rather than less. Users generally do not interact with things based on constructs like test-ids ([see our previous decision log about test-ids](https://github.com/Shopify/web-configs/blob/main/handbook/Decision%20records/04%20-%20We%20do%20not%20use%20test%20IDs.md)), or even by actual HTML attributes. The DOM itself is not a public API from a user's perspective.
 - Tests that rely on fine-grain knowledge of the DOM structure have a tendency to false-positive _and_ false-negative. It is extremely difficult to judge how a change in DOM structure which fails a test actually reflects a user's experience of the feature.
 - Tests which ignore component boundaries can easily rely on the implementation details of components potentially maintained by totally different teams. A test of a feature should not necessarily care about the implementation details of a button from a shared component library, just that the component/feature under test does what is expected.
 - For an ecosystem like React, the DOM is not the only intended output.

--- a/handbook/Meta/Web Foundations team.md
+++ b/handbook/Meta/Web Foundations team.md
@@ -1,14 +1,14 @@
-# Web Foundation team
+# Web Foundations team
 
-The Web Foundation team at Shopify is responsible for stewarding our approach to building web applications. It is important to note, however, that stewardship is the most apt description of the team’s role; it is not meant to dictate or police, particularly where doing so would interfere with another team being able to deliver their target experience.
+The Web Foundations team at Shopify is responsible for stewarding our approach to building web applications. It is important to note, however, that stewardship is the most apt description of the team’s role; it is not meant to dictate or police, particularly where doing so would interfere with another team being able to deliver their target experience.
 
 ## Responsibilities
 
-There are a few areas where the Web Foundation team takes a particularly prominent role. This section outlines these areas, as well as how the Web Foundation team decides on the degree of its involvement.
+There are a few areas where the Web Foundations team takes a particularly prominent role. This section outlines these areas, as well as how the Web Foundations team decides on the degree of its involvement.
 
 ### Language and platform experts
 
-While we expect all Web and UX Developers at Shopify to have a solid understanding of the web platform and associated technologies, the Web Foundation team is meant to serve as a consistent group of experts in these technologies that can assist other teams in addressing the Web, irrespective of the expertise they have on their own team. The Web Foundation team promises to maintain a modern and thorough understanding of the following:
+While we expect all Web and UX Developers at Shopify to have a solid understanding of the web platform and associated technologies, the Web Foundations team is meant to serve as a consistent group of experts in these technologies that can assist other teams in addressing the Web, irrespective of the expertise they have on their own team. The Web Foundations team promises to maintain a modern and thorough understanding of the following:
 
 * JavaScript (and variants in common use at Shopify, such as TypeScript)
 * Sass and CSS
@@ -18,29 +18,29 @@ While we expect all Web and UX Developers at Shopify to have a solid understandi
 * GraphQL
 * Frameworks and libraries in common use at Shopify, such as React and Koa
 
-Given this broad expertise in the platform and technologies of the Web, the Web Foundation team act as the stewards for our code style guides and the shared linting/ formatting configurations derived from these style guides. The Web Foundation team will, when necessary, break deadlocks in bike shedding around the stylistic use of the above technologies.
+Given this broad expertise in the platform and technologies of the Web, the Web Foundations team act as the stewards for our code style guides and the shared linting/formatting configurations derived from these style guides. The Web Foundations team will, when necessary, break deadlocks in bike shedding around the stylistic use of the above technologies.
 
-Additionally, the Web Foundation team should be at least a "keep informed" stakeholder on any project that involves a key extension or change to our typical process of developing for the Web, and for any project that involves significant and novel use of Web technologies not done elsewhere in Shopify.
+Additionally, the Web Foundations team should be at least a "keep informed" stakeholder on any project that involves a key extension or change to our typical process of developing for the Web, and for any project that involves significant and novel use of Web technologies not done elsewhere in Shopify.
 
 ### Stewards of common tools, libraries, and best practices
 
 At Shopify, we do not believe that every project should have completely free-reign in deciding their product’s tech stack. We expect projects to use our common developer tools, deploy systems, and production environments. We also make "picks" at higher levels in the stack that we believe are better served by consistency than developer choice, such as our preference for Rails as an application framework, or our preference for MySQL as the primary data store. These choices are often made in an effort to provide a minimum level of quality from all the products we create.
 
-The Web Foundation team applies this same principle of having sensible "picks" to developer tools, application libraries, and best practices specific to the Web platform. However, we are mindful of not creating "thin clients" — that is, leaving no decisions to application teams about what their application should look like.
+The Web Foundations team applies this same principle of having sensible "picks" to developer tools, application libraries, and best practices specific to the Web platform. However, we are mindful of not creating "thin clients" — that is, leaving no decisions to application teams about what their application should look like.
 
-#### Criteria for Web Foundation involvement
+#### Criteria for Web Foundations involvement
 
-The above description can be seen as overly broad, so the Web Foundation team uses the following criteria in deciding whether it should take a role in deciding best practices or preferred tools for a particular topic.
+The above description can be seen as overly broad, so the Web Foundations team uses the following criteria in deciding whether it should take a role in deciding best practices or preferred tools for a particular topic.
 
-The following criteria must **always** be met for the Web Foundation team to get involved:
+The following criteria must **always** be met for the Web Foundations team to get involved:
 
 * It **must not** interfere with a team’s ability to deliver value to their user. This has two implications:
-  1. The Web Foundation team only builds and maintains libraries that are either non-visual for the end user, or which operate in line with our design system, Polaris.
+  1. The Web Foundations team only builds and maintains libraries that are either non-visual for the end user, or which operate in line with our design system, Polaris.
   2. Any team feeling that our recommended best practices or libraries prevent them from being capable of delivering a user-facing feature should ignore the recommendation and bring this up with us.
-* It **must** be a topic that affects a majority of applications. The Web Foundation team will not build libraries that benefit only a small handful of projects; our work typically impacts at least 80% of merchants or internal developers.
+* It **must** be a topic that affects a majority of applications. The Web Foundations team will not build libraries that benefit only a small handful of projects; our work typically impacts at least 80% of merchants or internal developers.
 * It **must not** be a topic that has universal consensus in the industry.
 
-**At least one** of the following criteria must also be met for the Web Foundation team to get involved:
+**At least one** of the following criteria must also be met for the Web Foundations team to get involved:
 
 * It affects a key aspect of the user experience (performance, accessibility, etc) and is difficult for a typical developer to adequately address.
 * It has a material impact on the scalability of an application.
@@ -52,18 +52,18 @@ The following criteria must **always** be met for the Web Foundation team to get
 
 With these criteria in mind, the Web Foundations team is responsible for: 
 
-* **Deploy and development infrastructure.** To provide an excellent developer experience, JavaScript/ Node dependencies must be easy to install, publish, and deploy. The Web Foundation team maintains the integrations with core developer acceleration and production engineering tools like `dev` and `shipit` which enable the same development flow for JavaScript as for other "blessed" languages at Shopify.
+* **Deploy and development infrastructure.** To provide an excellent developer experience, JavaScript/ Node dependencies must be easy to install, publish, and deploy. The Web Foundations team maintains the integrations with core developer acceleration and production engineering tools like `dev` and `shipit` which enable the same development flow for JavaScript as for other "blessed" languages at Shopify.
 * **Build.** The build process for applications has an important impact on performance, as ineffective splitting and loading of assets can delay interactivity. Asynchronous loading of code also requires coordination of tooling, server, and client code. We consolidate our build tooling in [sewing-kit](https://github.com/Shopify/sewing-kit).
 * **Testing.** Testing is a key part of creating a scalable application that can be effectively shared/ transferred between developers. We provide recommendations on testing tools and best practices in this repo, and include a solid default testing experience in [sewing-kit](https://github.com/Shopify/sewing-kit).
-* **GraphQL.** GraphQL is vitally important to all applications at Shopify. In order to maintain a consistent approach between clients across platforms, the Web Foundation team coordinates its best practices and tooling with those of the mobile foundation team. Handling GraphQL effectively also involves tight integration with build, test, and type checking/ linting. We collect our GraphQL tooling in [graphql-tools-web](https://github.com/Shopify/graphql-tools-web), and provides an excellent default experience for GraphQL in [sewing-kit](https://github.com/Shopify/sewing-kit).
-* **Polaris.** The quality of the Web implementation of Polaris needs to be extraordinarily high, as any inadequacies are magnified by the number of applications that rely on Polaris for their core UI. The Web Foundation team does not directly maintain Polaris, but it works closely with the dedicated Polaris team to ensure that Polaris is optimized through [sewing-kit](https://github.com/Shopify/sewing-kit).
+* **GraphQL.** GraphQL is vitally important to all applications at Shopify. In order to maintain a consistent approach between clients across platforms, the Web Foundations team coordinates its best practices and tooling with those of the mobile foundation team. Handling GraphQL effectively also involves tight integration with build, test, and type checking/ linting. We collect our GraphQL tooling in [graphql-tools-web](https://github.com/Shopify/graphql-tools-web), and provides an excellent default experience for GraphQL in [sewing-kit](https://github.com/Shopify/sewing-kit).
+* **Polaris.** The quality of the Web implementation of Polaris needs to be extraordinarily high, as any inadequacies are magnified by the number of applications that rely on Polaris for their core UI. The Web Foundations team does not directly maintain Polaris, but it works closely with the dedicated Polaris team to ensure that Polaris is optimized through [sewing-kit](https://github.com/Shopify/sewing-kit).
 * **Common application libraries.** We maintain many additional libraries around our core technology picks that address common application needs. These libraries provide excellent default solutions and reduce the need for application developers to reinvent the wheel on every project, particularly where doing so effectively can be difficult, as it is in the case of forms, i18n, API authentication, and more. These libraries are included in the [quilt monorepo](https://github.com/Shopify/quilt).
 
 These responsibilities are summarized in the diagram below.
 
 <figure>
-  <img src="./images/Responsibilities%20-%20Shopify.png" alt="Web Foundation responsibilities for Shopify" />
-  <figcaption>A summary of components that the Web Foundation team is responsible for (the bottom four layers, highlighted in blue). Note that Polaris is listed as a responsibility of the Web Foundation team given its importance in our approach to building web apps, but its maintenance and evolution are handled by the dedicated Polaris team.</figcaption>
+  <img src="./images/Responsibilities%20-%20Shopify.png" alt="Web Foundations responsibilities for Shopify" />
+  <figcaption>A summary of components that the Web Foundations team is responsible for (the bottom four layers, highlighted in blue). Note that Polaris is listed as a responsibility of the Web Foundations team given its importance in our approach to building web apps, but its maintenance and evolution are handled by the dedicated Polaris team.</figcaption>
 </figure>
 
 ### Maintenance of foundational piece of Shopify Web
@@ -72,7 +72,7 @@ One problem that can arise from focusing on foundational technologies is that we
 
 Through applying our tools and libraries to Shopify Web, we can ensure they work well in practice, and that they scale to our largest applications. This provides us with confidence that they will work for other applications. Through ownership of some foundational elements of Shopify Web, we can discover pain points that may indicate missing or inadequate tools.
 
-There are three primary areas of Shopify Web that the Web Foundation team takes care of:
+There are three primary areas of Shopify Web that the Web Foundations team takes care of:
 
 * **Key dependencies.** We will ensure that Shopify Web stays up to date with key libraries like React, TypeScript, and Apollo. This forces us to ensure our tools built on top of these libraries continue to work for modern versions, and prevents us from holding other applications back from upgrading these dependencies in their own application.
 * **Infrastructure.** This includes everything from CI (to ensure that `sewing-kit` commands scale to our largest apps) and our server/ authentication (as these are very complex, and our team has the most expertise with Node).
@@ -80,13 +80,13 @@ There are three primary areas of Shopify Web that the Web Foundation team takes 
 
 These responsibilities are summarized in the following diagram:
 
-![Web Foundation responsibilities for Shopify Web](./images/Responsibilities%20-%20Web.png)
+![Web Foundations responsibilities for Shopify Web](./images/Responsibilities%20-%20Web.png)
 
 ## How we build
 
 We strive to achieve the following in everything we build:
 
-* **Open by default.** By the definition of our responsibilities above, the Web Foundation team does not typically deal with layers of an application that must be kept secret. As much as possible, we want to share our tools, techniques, and learnings with the outside development community.
+* **Open by default.** By the definition of our responsibilities above, the Web Foundations team does not typically deal with layers of an application that must be kept secret. As much as possible, we want to share our tools, techniques, and learnings with the outside development community.
 * **Minimize barrier to entry.** "Stewards, not dictators" can ring hollow if our projects make it impossible for members of other teams to contribute in whatever capacity they can manage. We will work to make sure it is easy to understand what contributions we are looking for. We will provide generators, documentation, and one-on-one chats that help developers find where to make those changes. Finally, we will endeavour to make it easy for developers to provide feedback on our tools and approaches, even if they are unable to directly contribute themselves.
 * **Best examples of our best practices.** A developer at Shopify should be able to look at the codebases we maintain and never experience cognitive dissonance with the guidelines we’ve presented. That means that every codebase is well tested, follows the same linting and formatting rules, and is architected in a way that is consistent with our [principles](../Principles). We maintain the foundational technology that is frequently used as an example other developers will follow, and so we hold ourselves to the highest standard of quality.
 * **The right way, not the fast way.** Sometimes, we will find challenges that indicate we may need larger refactors, potentially even to sibling projects. While a product team at Shopify might rightfully choose to take a scrappier approach, we will always opt for making the foundation we’ve built stronger, not weaker.

--- a/handbook/README.md
+++ b/handbook/README.md
@@ -1,3 +1,3 @@
-# Web foundation - Handbook
+# Web foundations - Handbook
 
 This handbook is the living guide to how we build web UI at Shopify. It captures the [principles](./Principles) we use to make decisions, our [best practices](./Best%20practices) and [styleguides](./Styleguides) for writing UI code, and a [log of decisions](./Decision%20records) that led us to this foundation. It also provides a list of [resources](./Resources) for mastering the different parts of web UI development.

--- a/handbook/Resources/workshops.md
+++ b/handbook/Resources/workshops.md
@@ -4,7 +4,7 @@
 
 * [Github Repo](https://github.com/Shopify/web-workshop)
 
-This is a 5 hour workshop originally written for RnD Summit 2018. The workshop begins by covering the high-level priciples of the web-foundation team, it then moves on to demonstrate their practical application while coding a private Shopify App that communicates with the Shopify Admin GraphQL API. With a mix of lectures, individual exercises, and live-coding together, the workshop covers the core languages of the Web stack (React, Typescript, GraphQL) as well as our internal libraries (Sewing Kit, Polaris, Quilt).
+This is a 5 hour workshop originally written for RnD Summit 2018. The workshop begins by covering the high-level priciples of the Web Foundations team, it then moves on to demonstrate their practical application while coding a private Shopify App that communicates with the Shopify Admin GraphQL API. With a mix of lectures, individual exercises, and live-coding together, the workshop covers the core languages of the Web stack (React, Typescript, GraphQL) as well as our internal libraries (Sewing Kit, Polaris, Quilt).
 
 ### Owners
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "web-foundation",
+  "name": "web-configs",
   "author": "Shopify Inc.",
   "license": "MIT",
   "private": true,

--- a/packages/babel-preset/README.md
+++ b/packages/babel-preset/README.md
@@ -1,6 +1,5 @@
 # `@shopify/babel-preset`
 
-[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=main)](https://travis-ci.com/Shopify/web-foundation)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](../../LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fbabel-preset.svg)](https://badge.fury.io/js/%40shopify%2Fbabel-preset.svg)
 
 Shopify’s org-wide set of Babel transforms.

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -11,13 +11,13 @@
   "author": "Shopify Inc.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Shopify/web-foundation.git",
+    "url": "git+https://github.com/Shopify/web-configs.git",
     "directory": "packages/babel-preset"
   },
   "bugs": {
-    "url": "https://github.com/Shopify/web-foundation/issues"
+    "url": "https://github.com/Shopify/web-configs/issues"
   },
-  "homepage": "https://github.com/Shopify/web-foundation/blob/main/packages/babel-preset/README.md",
+  "homepage": "https://github.com/Shopify/web-configs/blob/main/packages/babel-preset/README.md",
   "dependencies": {
     "@babel/core": "^7.10.4",
     "@babel/plugin-proposal-class-properties": "^7.10.4",

--- a/packages/browserslist-config/README.md
+++ b/packages/browserslist-config/README.md
@@ -1,6 +1,5 @@
 # `@shopify/browserslist-config`
 
-[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=main)](https://travis-ci.com/Shopify/web-foundation)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](../../LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fbrowserslist-config.svg)](https://badge.fury.io/js/%40shopify%2Fbrowserslist-config.svg)
 
 Shareable [browserslist](https://github.com/ai/browserslist) configuration for Shopify.

--- a/packages/browserslist-config/package.json
+++ b/packages/browserslist-config/package.json
@@ -15,13 +15,13 @@
   "author": "Shopify Inc.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Shopify/web-foundation.git",
+    "url": "git+https://github.com/Shopify/web-configs.git",
     "directory": "packages/browserslist-config"
   },
   "bugs": {
-    "url": "https://github.com/Shopify/web-foundation/issues"
+    "url": "https://github.com/Shopify/web-configs/issues"
   },
-  "homepage": "https://github.com/Shopify/web-foundation/blob/main/packages/browserslist-config/README.md",
+  "homepage": "https://github.com/Shopify/web-configs/blob/main/packages/browserslist-config/README.md",
   "devDependencies": {
     "browserslist": "^4.3.4"
   }

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -1,6 +1,5 @@
 # `@shopify/eslint-plugin`
 
-[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=main)](https://travis-ci.com/Shopify/web-foundation)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](../../LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Feslint-plugin.svg)](https://badge.fury.io/js/%40shopify%2Feslint-plugin.svg)
 
 Shopify’s ESLint rules and configs.

--- a/packages/eslint-plugin/docs/rules/jest/no-all-mocks-methods.md
+++ b/packages/eslint-plugin/docs/rules/jest/no-all-mocks-methods.md
@@ -32,4 +32,4 @@ jest.mock();
 
 ## Further Reading
 
-- [Shopify Jest Best Practices](https://github.com/Shopify/web-foundation/blob/main/handbook/Best%20practices/Jest.md#best-practices)
+- [Shopify Jest Best Practices](https://github.com/Shopify/web-configs/blob/main/handbook/Best%20practices/Jest.md#best-practices)

--- a/packages/eslint-plugin/docs/rules/jest/no-snapshots.md
+++ b/packages/eslint-plugin/docs/rules/jest/no-snapshots.md
@@ -36,4 +36,4 @@ If you do not wish to prevent the use of jest snapshots, you can safely disable 
 
 ## Further Reading
 
-- [Shopify Jest Best Practices](https://github.com/Shopify/web-foundation/blob/main/handbook/Best%20practices/Jest.md#best-practices)
+- [Shopify Jest Best Practices](https://github.com/Shopify/web-configs/blob/main/handbook/Best%20practices/Jest.md#best-practices)

--- a/packages/eslint-plugin/lib/rules/jest/no-all-mocks-methods.js
+++ b/packages/eslint-plugin/lib/rules/jest/no-all-mocks-methods.js
@@ -5,7 +5,7 @@ module.exports = {
       category: 'Best Practices',
       recommended: false,
       uri:
-        'https://github.com/Shopify/web-foundation/blob/main/packages/eslint-plugin/docs/rules/jest/no-all-mocks-methods.md',
+        'https://github.com/Shopify/web-configs/blob/main/packages/eslint-plugin/docs/rules/jest/no-all-mocks-methods.md',
     },
   },
   messages: {

--- a/packages/eslint-plugin/lib/utilities/index.js
+++ b/packages/eslint-plugin/lib/utilities/index.js
@@ -3,7 +3,7 @@ const {join, dirname, relative, basename} = require('path');
 const resolve = require('eslint-module-utils/resolve').default;
 const pkgDir = require('pkg-dir');
 
-const REPO_URL = 'https://github.com/Shopify/web-foundation';
+const REPO_URL = 'https://github.com/Shopify/web-configs';
 
 function uncast(node) {
   let currentNode = node;

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -17,13 +17,13 @@
   "author": "Shopify Inc.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Shopify/web-foundation.git",
+    "url": "git+https://github.com/Shopify/web-configs.git",
     "directory": "packages/eslint-plugin"
   },
   "bugs": {
-    "url": "https://github.com/Shopify/web-foundation/issues"
+    "url": "https://github.com/Shopify/web-configs/issues"
   },
-  "homepage": "https://github.com/Shopify/web-foundation/blob/main/packages/eslint-plugin/README.md",
+  "homepage": "https://github.com/Shopify/web-configs/blob/main/packages/eslint-plugin/README.md",
   "devDependencies": {
     "graphql": "^14.6.0",
     "react": "^16.13.1",

--- a/packages/eslint-plugin/tests/lib/utilities.test.js
+++ b/packages/eslint-plugin/tests/lib/utilities.test.js
@@ -4,19 +4,19 @@ describe('utilities', () => {
   describe('docsUrl()', () => {
     it('returns the repo documentation url when given a rule name', () => {
       expect(docsUrl('some-fake-rule')).toBe(
-        'https://github.com/Shopify/web-foundation/blob/main/packages/eslint-plugin/docs/rules/some-fake-rule.md',
+        'https://github.com/Shopify/web-configs/blob/main/packages/eslint-plugin/docs/rules/some-fake-rule.md',
       );
       expect(docsUrl('another-fake-rule')).toBe(
-        'https://github.com/Shopify/web-foundation/blob/main/packages/eslint-plugin/docs/rules/another-fake-rule.md',
+        'https://github.com/Shopify/web-configs/blob/main/packages/eslint-plugin/docs/rules/another-fake-rule.md',
       );
     });
 
     it('returns the repo documentation url when given a prefixed rule name', () => {
       expect(docsUrl('jest/some-fake-rule')).toBe(
-        'https://github.com/Shopify/web-foundation/blob/main/packages/eslint-plugin/docs/rules/jest/some-fake-rule.md',
+        'https://github.com/Shopify/web-configs/blob/main/packages/eslint-plugin/docs/rules/jest/some-fake-rule.md',
       );
       expect(docsUrl('typescript/another-fake-rule')).toBe(
-        'https://github.com/Shopify/web-foundation/blob/main/packages/eslint-plugin/docs/rules/typescript/another-fake-rule.md',
+        'https://github.com/Shopify/web-configs/blob/main/packages/eslint-plugin/docs/rules/typescript/another-fake-rule.md',
       );
     });
   });

--- a/packages/images/README.md
+++ b/packages/images/README.md
@@ -1,6 +1,5 @@
 # `@shopify/images`
 
-[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=main)](https://travis-ci.com/Shopify/web-foundation)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](../../LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fimages.svg)](https://badge.fury.io/js/%40shopify%2Fimages.svg)
 
 Tools to help us wrangle images at Shopify.

--- a/packages/images/package.json
+++ b/packages/images/package.json
@@ -11,13 +11,13 @@
   "author": "Shopify Inc.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Shopify/web-foundation.git",
+    "url": "git+https://github.com/Shopify/web-configs.git",
     "directory": "packages/images"
   },
   "bugs": {
-    "url": "https://github.com/Shopify/web-foundation/issues"
+    "url": "https://github.com/Shopify/web-configs/issues"
   },
-  "homepage": "https://github.com/Shopify/web-foundation/blob/main/packages/images/README.md",
+  "homepage": "https://github.com/Shopify/web-configs/blob/main/packages/images/README.md",
   "devDependencies": {
     "svgo": "^1.3.2"
   }

--- a/packages/postcss-plugin/README.md
+++ b/packages/postcss-plugin/README.md
@@ -1,6 +1,5 @@
 # `@shopify/postcss-plugin`
 
-[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=main)](https://travis-ci.com/Shopify/web-foundation)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](../../LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fpostcss-plugin.svg)](https://badge.fury.io/js/%40shopify%2Fpostcss-plugin.svg)
 
 All of Shopify’s preferred [PostCSS](https://github.com/postcss/postcss) plugins wrapped up in a single, easy-to-use plugin.

--- a/packages/postcss-plugin/package.json
+++ b/packages/postcss-plugin/package.json
@@ -17,13 +17,13 @@
   "author": "Shopify Inc.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Shopify/web-foundation.git",
+    "url": "git+https://github.com/Shopify/web-configs.git",
     "directory": "packages/postcss-plugin"
   },
   "bugs": {
-    "url": "https://github.com/Shopify/web-foundation/issues"
+    "url": "https://github.com/Shopify/web-configs/issues"
   },
-  "homepage": "https://github.com/Shopify/web-foundation/blob/main/packages/postcss-plugin/README.md",
+  "homepage": "https://github.com/Shopify/web-configs/blob/main/packages/postcss-plugin/README.md",
   "dependencies": {
     "autoprefixer": "9.8.6",
     "cssnano": "4.1.10",

--- a/packages/prettier-config/CHANGELOG.md
+++ b/packages/prettier-config/CHANGELOG.md
@@ -15,4 +15,4 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Created `@shopify/prettier-config` package ([#152](https://github.com/Shopify/web-foundation/pull/152))
+- Created `@shopify/prettier-config` package ([#152](https://github.com/Shopify/web-configs/pull/152))

--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -1,6 +1,5 @@
 # `@shopify/prettier-config`
 
-[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=main)](https://travis-ci.com/Shopify/web-foundation)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](../../LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fprettier-config.svg)](https://badge.fury.io/js/%40shopify%2Fprettier-config.svg)  [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/prettier-config.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/prettier-config.svg)
 
 Shared prettier configuration

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -12,11 +12,11 @@
   "author": "Shopify Inc.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Shopify/web-foundation.git",
+    "url": "git+https://github.com/Shopify/web-configs.git",
     "directory": "packages/prettier-config"
   },
   "bugs": {
-    "url": "https://github.com/Shopify/web-foundation/issues"
+    "url": "https://github.com/Shopify/web-configs/issues"
   },
-  "homepage": "https://github.com/Shopify/web-foundation/blob/main/packages/prettier-config/README.md"
+  "homepage": "https://github.com/Shopify/web-configs/blob/main/packages/prettier-config/README.md"
 }

--- a/packages/stylelint-plugin/README.md
+++ b/packages/stylelint-plugin/README.md
@@ -1,6 +1,5 @@
 # `@shopify/stylelint-plugin`
 
-[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=main)](https://travis-ci.com/Shopify/web-foundation)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](../../LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fstylelint-plugin.svg)](https://badge.fury.io/js/%40shopify%2Fstylelint-plugin.svg)
 
 Shopify's stylelint rules and config

--- a/packages/stylelint-plugin/package.json
+++ b/packages/stylelint-plugin/package.json
@@ -17,13 +17,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Shopify/web-foundation.git",
+    "url": "git+https://github.com/Shopify/web-configs.git",
     "directory": "packages/stylelint-plugin"
   },
   "bugs": {
-    "url": "https://github.com/Shopify/web-foundation/issues"
+    "url": "https://github.com/Shopify/web-configs/issues"
   },
-  "homepage": "https://github.com/Shopify/web-foundation/blob/main/packages/stylelint-plugin/README.md",
+  "homepage": "https://github.com/Shopify/web-configs/blob/main/packages/stylelint-plugin/README.md",
   "dependencies": {
     "merge": "^1.2.1",
     "stylelint-config-prettier": "^8.0.1",

--- a/packages/typescript-configs/CHANGELOG.md
+++ b/packages/typescript-configs/CHANGELOG.md
@@ -25,7 +25,7 @@ After:
 import styles from 'foo.scss';
 ```
 
-- Updated the `*.scss` and `*.css` types for esmodules [[#165](https://github.com/Shopify/web-foundation/pull/165)]
+- Updated the `*.scss` and `*.css` types for esmodules [[#165](https://github.com/Shopify/web-configs/pull/165)]
 
 ## [2.0.2] - 2020-03-28
 

--- a/packages/typescript-configs/README.md
+++ b/packages/typescript-configs/README.md
@@ -1,6 +1,5 @@
 # `@shopify/typescript-configs`
 
-[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=main)](https://travis-ci.com/Shopify/web-foundation)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](../../LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Ftypescript-configs.svg)](https://badge.fury.io/js/%40shopify%2Ftypescript-configs.svg)
 
 In TypeScript, the configuration file can extend from a base file. This package provided a few common base configuration files to simplify TypeScript project setup.

--- a/packages/typescript-configs/package.json
+++ b/packages/typescript-configs/package.json
@@ -10,11 +10,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Shopify/web-foundation.git",
+    "url": "git+https://github.com/Shopify/web-configs.git",
     "directory": "packages/typescript-configs"
   },
   "bugs": {
-    "url": "https://github.com/Shopify/web-foundation/issues"
+    "url": "https://github.com/Shopify/web-configs/issues"
   },
-  "homepage": "https://github.com/Shopify/web-foundation/blob/main/packages/typescript-configs/README.md"
+  "homepage": "https://github.com/Shopify/web-configs/blob/main/packages/typescript-configs/README.md"
 }

--- a/templates/README.hbs.md
+++ b/templates/README.hbs.md
@@ -1,6 +1,5 @@
 # `@shopify/{{name}}`
 
-[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=main)](https://travis-ci.com/Shopify/web-foundation)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](../../LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2F{{name}}.svg)](https://badge.fury.io/js/%40shopify%2F{{name}}.svg) {{#if usedInBrowser}} [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/{{name}}.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/{{name}}.svg) {{/if}}
 
 {{description}}

--- a/templates/ROOT_README.hbs.md
+++ b/templates/ROOT_README.hbs.md
@@ -1,19 +1,15 @@
 [comment]: # (NOTE: This file is generated and should not be modify directly. Update `templates/ROOT_README.hbs.md` instead)
 
-**Note: Old documentations on the root level had been move inside the [handbook](handbook) directory of this repository**
-
-# Web foundation
+# Web Configs
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md)
-[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=main)](https://travis-ci.com/Shopify/web-foundation)
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lernajs.io/)
 
 This repository contains common configuration and living [guidances](handbook) that Shopify uses to build web UI.
 
 ## Usage
 
-The Web foundation repo is managed as a monorepo that is composed of many npm packages.
-Each package has its own `README` and documentation describing usage.
+This repo is managed as a monorepo that is composed of many npm packages, where each package has its own `README` and documentation describing usage.
 
 ### Package Index
 
@@ -25,11 +21,7 @@ Each package has its own `README` and documentation describing usage.
 
 ## Want to contribute?
 
-Check out our [Contributing Guide](./.github/CONTRIBUTING.md)
-
-## Questions?
-
-For Shopifolk, you can reach out to us in Slack in the `#web-foundation-tech` channel. For external inquiries, we welcome bug reports, enhancements, and feature requests via Github issues.
+Check out our [Contributing Guide](./.github/CONTRIBUTING.md). We welcome bug reports, enhancements, and feature requests via Github issues.
 
 ## License
 

--- a/templates/package.hbs.json
+++ b/templates/package.hbs.json
@@ -16,8 +16,8 @@
     "directory": "packages/{{name}}"
   },
   "bugs": {
-    "url": "https://github.com/Shopify/web-foundation/issues"
+    "url": "https://github.com/Shopify/web-configs/issues"
   },
-  "homepage": "https://github.com/Shopify/web-foundation/blob/main/packages/{{name}}/README.md",
+  "homepage": "https://github.com/Shopify/web-configs/blob/main/packages/{{name}}/README.md",
   "dependencies": {}
 }


### PR DESCRIPTION
## Description

This PR aims to begin the process of rename, restructuring and rebuilding this repo to its mandate of providing internal and external developers with an opinionated set of common configuration to build web UI. 

### Updates

- Renaming packages and references to `@shopify/web-foundations` to `@shopify/web-configs`

    - _To make sure we don't break anything, we'll make the repository name change first, and then ship this PR immediately after._

- Change all references from `Web Foundation` to `Web Foundations`, which is our team's name

- Removed some references to Shopify based, internal-only tools, as an open-sourced repository should aim for internal/external parity and open collaboration when possible

- Remove broken and unused TravisCI build badges


### Next Steps

With this being a public-first repository, our goal should be to remove our internal-only tools and documents.

- Move away from Shipit for releasing
- Remove/Reorganize our development handbook, and team handbook, to better align with the mission of this repository
- Update essential package documentation


## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
